### PR TITLE
feat: Task-7 - Implement authorization to import endpoint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ dist
 # CDK asset staging directory
 .cdk.staging
 cdk.out
+
+.env

--- a/bin/vinyl-shop-product-service.ts
+++ b/bin/vinyl-shop-product-service.ts
@@ -2,9 +2,11 @@
 import * as cdk from 'aws-cdk-lib';
 import { VinylShopProductServiceStack } from '../lib/vinyl-shop-product-service-stack';
 import { ImportServiceStack } from '../lib/import-service-stack';
+import { AuthorizationServiceStack } from '../lib/authorization-service-stack';
 
 const app = new cdk.App();
 const productStack = new VinylShopProductServiceStack(app, 'VinylShopProductServiceStack', {});
+const authorizationStack = new AuthorizationServiceStack(app, 'AuthorizationServiceStack', {});
 
 const importStack = new ImportServiceStack(app, 'ImportServiceStack', {
   catalogItemsQueue: productStack.catalogItemsQueue,

--- a/lib/authorization-service-stack.ts
+++ b/lib/authorization-service-stack.ts
@@ -1,0 +1,38 @@
+import * as cdk from 'aws-cdk-lib';
+import * as lambda from 'aws-cdk-lib/aws-lambda';
+import { Construct } from 'constructs';
+import * as path from 'path';
+import * as fs from 'fs';
+import * as dotenv from 'dotenv';
+
+export class AuthorizationServiceStack extends cdk.Stack {
+    constructor(scope: Construct, id: string, props?: cdk.StackProps) {
+        super(scope, id, props);
+
+        const envPath = path.join(__dirname, '..', '.env');
+        const envConfig = dotenv.parse(fs.readFileSync(envPath));
+
+        const basicAuthorizer = new lambda.Function(this, 'basic-authorizer-function', {
+            runtime: lambda.Runtime.NODEJS_20_X,
+            memorySize: 1024,
+            timeout: cdk.Duration.seconds(5),
+            handler: 'basicAuthorizer.main',
+            code: lambda.Code.fromAsset(path.join(__dirname, '../dist/src/lambdas')),
+            environment: {
+                ...envConfig,
+            }
+        });
+
+        basicAuthorizer.addPermission('AllowApiGatewayInvoke', {
+            principal: new cdk.aws_iam.ServicePrincipal('apigateway.amazonaws.com'),
+            action: 'lambda:InvokeFunction',
+            sourceArn: `arn:aws:execute-api:${this.region}:${this.account}:*`,
+        });
+
+        new cdk.CfnOutput(this, 'basicAuthorizerArn', {
+            value: basicAuthorizer.functionArn,
+            description: 'Basic Authorizer Lambda Function ARN',
+            exportName: 'basicAuthorizerFunctionArn',
+        });
+    }
+}

--- a/lib/import-service-stack.ts
+++ b/lib/import-service-stack.ts
@@ -57,8 +57,8 @@ export class ImportServiceStack extends cdk.Stack {
             restApiName: 'Import Service',
             description: 'This service handles import products file by returned signed URL',
             defaultCorsPreflightOptions: {
-                allowOrigins: ['https://d2h8spcnjjuho2.cloudfront.net/', 'http://localhost:3000'],
-                allowMethods: ['GET', 'OPTIONS'],
+                allowOrigins: ['*'],
+                allowMethods: ['*'],
             },
         });
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,12 +14,14 @@
         "@aws-sdk/client-sqs": "^3.817.0",
         "@aws-sdk/lib-dynamodb": "^3.799.0",
         "@aws-sdk/s3-request-presigner": "^3.810.0",
+        "@aws-sdk/util-base64": "^3.310.0",
         "@types/aws-lambda": "^8.10.149",
         "@types/uuid": "^10.0.0",
         "aws-cdk-lib": "2.186.0",
         "aws-lambda": "^1.0.7",
         "constructs": "^10.0.0",
         "csv-parser": "^3.2.0",
+        "dotenv": "^16.5.0",
         "uuid": "^11.1.0"
       },
       "bin": {
@@ -2017,6 +2019,18 @@
         "node": ">=18.0.0"
       }
     },
+    "node_modules/@aws-sdk/is-array-buffer": {
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-3.310.0.tgz",
+      "integrity": "sha512-urnbcCR+h9NWUnmOtet/s4ghvzsidFmspfhYaHAmSRdy9yDjdjBJMFjjsn85A1ODUktztm+cVncXjQ38WCMjMQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/@aws-sdk/lib-dynamodb": {
       "version": "3.799.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/lib-dynamodb/-/lib-dynamodb-3.799.0.tgz",
@@ -2546,6 +2560,32 @@
       },
       "engines": {
         "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-base64": {
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64/-/util-base64-3.310.0.tgz",
+      "integrity": "sha512-v3+HBKQvqgdzcbL+pFswlx5HQsd9L6ZTlyPVL2LS9nNXnCcR3XgGz9jRskikRUuUvUXtkSG1J88GAOnJ/apTPg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/util-buffer-from": "3.310.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-buffer-from": {
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-buffer-from/-/util-buffer-from-3.310.0.tgz",
+      "integrity": "sha512-i6LVeXFtGih5Zs8enLrt+ExXY92QV25jtEnTKHsmlFqFAuL3VBeod6boeMXkN2p9lbSVVQ1sAOOYZOHYbYkntw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/is-array-buffer": "3.310.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/util-dynamodb": {
@@ -6136,6 +6176,18 @@
       "license": "MIT",
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "16.5.0",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.5.0.tgz",
+      "integrity": "sha512-m/C+AwOAr9/W1UOIZUo232ejMNnJAJtYQjUbHoNTBNTJSvqzzDh7vnrei3o3r3m9blf6ZoDkvcw0VmozNRFJxg==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
       }
     },
     "node_modules/dunder-proto": {

--- a/package.json
+++ b/package.json
@@ -32,12 +32,14 @@
     "@aws-sdk/client-sqs": "^3.817.0",
     "@aws-sdk/lib-dynamodb": "^3.799.0",
     "@aws-sdk/s3-request-presigner": "^3.810.0",
+    "@aws-sdk/util-base64": "^3.310.0",
     "@types/aws-lambda": "^8.10.149",
     "@types/uuid": "^10.0.0",
     "aws-cdk-lib": "2.186.0",
     "aws-lambda": "^1.0.7",
     "constructs": "^10.0.0",
     "csv-parser": "^3.2.0",
+    "dotenv": "^16.5.0",
     "uuid": "^11.1.0"
   }
 }

--- a/src/lambdas/basicAuthorizer.ts
+++ b/src/lambdas/basicAuthorizer.ts
@@ -1,0 +1,51 @@
+import { APIGatewayAuthorizerResult, APIGatewayTokenAuthorizerEvent, StatementEffect } from 'aws-lambda';
+import { fromBase64 } from '@aws-sdk/util-base64';
+
+export async function main(event: APIGatewayTokenAuthorizerEvent): Promise<APIGatewayAuthorizerResult> {
+    console.log(`Request received in basicAuthorizer lambda function with event: ${JSON.stringify(event)}`);
+    const token = event.authorizationToken;
+
+    if (!token || !token.startsWith('Basic ')) {
+        // This will trigger a 401 response
+        console.log('Token is not present');
+        throw new Error('Unauthorized');
+    }
+
+    try {
+        const base64Credentials = token.replace('Basic ', '');
+        const credentials = new TextDecoder().decode(fromBase64(base64Credentials));
+        const [username, password] = credentials.split(':');
+
+        const isValid = checkCredentials(username, password);
+
+        if (!isValid) {
+            // Trigger a 403 - Forbidden status response
+            return generatePolicy('user', 'Deny', event.methodArn);
+        }
+
+        console.log('User is authorized to continue with request.');
+        return generatePolicy(username, 'Allow', event.methodArn);
+    } catch (error) {
+        throw new Error('Something went wrong while authorizing user.');
+    }
+}
+
+function checkCredentials(username: string, password: string): Boolean {
+    return !!(process.env[username] && process.env[username] === password);
+}
+
+function generatePolicy(user: string, effect: StatementEffect, methodArn: string): APIGatewayAuthorizerResult {
+    return {
+        principalId: user,
+        policyDocument: {
+            Version: '2012-10-17',
+            Statement: [
+                {
+                    Action: 'execute-api:Invoke',
+                    Effect: effect,
+                    Resource: methodArn,
+                },
+            ],
+        },
+    };
+}


### PR DESCRIPTION
# Changes
- Added `authorization-service` to the CDK project
- Added `basicAuthorizer` lambda to be added as authorizer of import lambda
- Added logic to return a `401` status code response when authorization header is not present
- Added logic to return a `403` status code response when credentials does not match the allowed user.

<img width="625" alt="image" src="https://github.com/user-attachments/assets/b796bfd8-60bf-46c1-8891-72364925310c" />

<img width="636" alt="image" src="https://github.com/user-attachments/assets/5f5a82f3-4289-4799-9fde-11e454ab329d" />

# Link to `/import` Endpoint:
- import: https://k96x73rxtc.execute-api.us-west-1.amazonaws.com/prod/import

**NOTE:** Replace the `-` with a `_` from my github user for testing.

# Link to Frontend PR
- https://github.com/the-rodz/shop-react-redux-cloudfront/pull/4

<img width="859" alt="image" src="https://github.com/user-attachments/assets/c778c495-7959-4f4d-83ab-e22c2a2fa203" />
